### PR TITLE
Install Windows Perl and fix cc::windows_registry::find.

### DIFF
--- a/docker/Dockerfile.aarch64-pc-windows-msvc-cross
+++ b/docker/Dockerfile.aarch64-pc-windows-msvc-cross
@@ -17,12 +17,22 @@ RUN /msvc-wine.sh
 COPY wine.sh /
 RUN /wine.sh
 
+# need windows-style perl for paths
+COPY cross-toolchains/docker/perl.sh /
+RUN /perl.sh
+
+ARG ARCH=arm64
 COPY cross-toolchains/docker/msvc-wine-symlink.sh /
-RUN /msvc-wine-symlink.sh arm64
+RUN /msvc-wine-symlink.sh $ARCH
 
 COPY cross-toolchains/docker/msvc-windows-entry.sh /
 ENTRYPOINT ["/msvc-windows-entry.sh"]
 
 ENV CARGO_TARGET_AARCH64_PC_WINDOWS_MSVC_LINKER=link.exe \
     CC_aarch64_pc_windows_msvc=cl.exe \
-    CXX_aarch64_pc_windows_msvc=cl.exe
+    CXX_aarch64_pc_windows_msvc=cl.exe \
+    PATH=/opt/msvc/bin/$ARCH:/opt/bin:$PATH \
+    WINEPATH="$WINEPATH;C:/windows/syswow64;C:/windows/system32;/opt/msvc/bin/$ARCH" \
+    VSINSTALLDIR="/opt/msvc" \
+    VCINSTALLDIR="/opt/msvc/vc" \
+    VSCMD_ARG_TGT_ARCH=$ARCH

--- a/docker/Dockerfile.i686-pc-windows-msvc-cross
+++ b/docker/Dockerfile.i686-pc-windows-msvc-cross
@@ -17,8 +17,13 @@ RUN /msvc-wine.sh
 COPY wine.sh /
 RUN /wine.sh
 
+# need windows-style perl for paths
+COPY cross-toolchains/docker/perl.sh /
+RUN /perl.sh
+
+ARG ARCH=x86
 COPY cross-toolchains/docker/msvc-wine-symlink.sh /
-RUN /msvc-wine-symlink.sh x86
+RUN /msvc-wine-symlink.sh $ARCH
 
 # run-detectors are responsible for calling the correct interpreter for exe
 # files. For some reason it does not work inside a docker container (it works
@@ -37,4 +42,9 @@ ENTRYPOINT ["/msvc-windows-entry.sh"]
 ENV CARGO_TARGET_I686_PC_WINDOWS_MSVC_LINKER=link.exe \
     CARGO_TARGET_I686_PC_WINDOWS_MSVC_RUNNER=wine \
     CC_i686_pc_windows_msvc=cl.exe \
-    CXX_i686_pc_windows_msvc=cl.exe
+    CXX_i686_pc_windows_msvc=cl.exe \
+    PATH=/opt/msvc/bin/$ARCH:/opt/bin:$PATH \
+    WINEPATH="$WINEPATH;C:/windows/syswow64;C:/windows/system32;/opt/msvc/bin/$ARCH" \
+    VSINSTALLDIR="/opt/msvc" \
+    VCINSTALLDIR="/opt/msvc/vc" \
+    VSCMD_ARG_TGT_ARCH=$ARCH

--- a/docker/Dockerfile.thumbv7a-pc-windows-msvc-cross
+++ b/docker/Dockerfile.thumbv7a-pc-windows-msvc-cross
@@ -17,12 +17,22 @@ RUN /msvc-wine.sh
 COPY wine.sh /
 RUN /wine.sh
 
+# need windows-style perl for paths
+COPY cross-toolchains/docker/perl.sh /
+RUN /perl.sh
+
+ARG ARCH=arm
 COPY cross-toolchains/docker/msvc-wine-symlink.sh /
-RUN /msvc-wine-symlink.sh arm
+RUN /msvc-wine-symlink.sh $ARCH
 
 COPY cross-toolchains/docker/msvc-windows-entry.sh /
 ENTRYPOINT ["/msvc-windows-entry.sh"]
 
 ENV CARGO_TARGET_THUMBV7A_PC_WINDOWS_MSVC_LINKER=link.exe \
     CC_thumbv7a_pc_windows_msvc=cl.exe \
-    CXX_thumbv7a_pc_windows_msvc=cl.exe
+    CXX_thumbv7a_pc_windows_msvc=cl.exe \
+    PATH=/opt/msvc/bin/$ARCH:/opt/bin:$PATH \
+    WINEPATH="$WINEPATH;C:/windows/syswow64;C:/windows/system32;/opt/msvc/bin/$ARCH" \
+    VSINSTALLDIR="/opt/msvc" \
+    VCINSTALLDIR="/opt/msvc/vc" \
+    VSCMD_ARG_TGT_ARCH=$ARCH

--- a/docker/Dockerfile.x86_64-pc-windows-msvc-cross
+++ b/docker/Dockerfile.x86_64-pc-windows-msvc-cross
@@ -17,8 +17,13 @@ RUN /msvc-wine.sh
 COPY wine.sh /
 RUN /wine.sh
 
+# need windows-style perl for paths
+COPY cross-toolchains/docker/perl.sh /
+RUN /perl.sh
+
+ARG ARCH=x64
 COPY cross-toolchains/docker/msvc-wine-symlink.sh /
-RUN /msvc-wine-symlink.sh x64
+RUN /msvc-wine-symlink.sh $ARCH
 
 # run-detectors are responsible for calling the correct interpreter for exe
 # files. For some reason it does not work inside a docker container (it works
@@ -37,4 +42,9 @@ ENTRYPOINT ["/msvc-windows-entry.sh"]
 ENV CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=link.exe \
     CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUNNER=wine \
     CC_x86_64_pc_windows_msvc=cl.exe \
-    CXX_x86_64_pc_windows_msvc=cl.exe
+    CXX_x86_64_pc_windows_msvc=cl.exe \
+    PATH=/opt/msvc/bin/$ARCH:/opt/bin:$PATH \
+    WINEPATH="$WINEPATH;C:/windows/syswow64;C:/windows/system32;/opt/msvc/bin/$ARCH" \
+    VSINSTALLDIR="/opt/msvc" \
+    VCINSTALLDIR="/opt/msvc/vc" \
+    VSCMD_ARG_TGT_ARCH=$ARCH

--- a/docker/msvc-wine-symlink.sh
+++ b/docker/msvc-wine-symlink.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016
 
 set -x
 set -euo pipefail
@@ -6,17 +7,15 @@ set -euo pipefail
 main() {
     local arch="${1}"
 
-    # need to create scripts to speed up compilation, since binfmt is slow
-    # the use of wine64 is also super slow, so we want our own wrappers.
-    local src="/opt/msvc/bin/${arch}"
-    local dst="/usr/local/bin"
-    local srcf
-    local dstf
-    for srcf in "$src"/*.exe; do
-        dstf=$(basename "${srcf}")
-        echo -e '#!/usr/bin/env bash\nwine '"${srcf}"' "${@}"' > "${dst}/${dstf}"
-        chmod +x "${dst}/${dstf}"
-    done
+    # speed up scripts by specifying wine instead of wine64
+    local prefix="/opt/msvc/bin/${arch}"
+    sed -i 's/wine64/wine/g' "${prefix}/wine-msvc.sh"
+
+    # need to specifically fix cmd, so it uses windows cmd.
+    echo -e '#!/usr/bin/env bash\nwine cmd "${@}"' > "${prefix}/cmd"
+    echo -e '#!/usr/bin/env bash\nwine cmd "${@}"' > "${prefix}/cmd.exe"
+    chmod +x "${prefix}/cmd"
+    chmod +x "${prefix}/cmd.exe"
 
     rm "${0}"
 }

--- a/docker/perl.sh
+++ b/docker/perl.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+
+set -x
+set -euo pipefail
+
+# shellcheck disable=SC1091
+. lib.sh
+
+main() {
+    local version="5.32.1.1"
+    local home="https://strawberryperl.com/download"
+    local arch="64"
+    local file="strawberry-perl-${version}-${arch}bit-portable.zip"
+    local url="${home}/${version}/${file}"
+
+    install_packages wget unzip
+
+    local td
+    td="$(mktemp -d)"
+
+    pushd "${td}"
+    wget "${url}"
+    unzip "${file}" -d /opt/perl
+
+    local src="/opt/perl/perl/bin"
+    local dst="/opt/bin"
+    mkdir -p "${dst}"
+    echo -e '#!/usr/bin/env bash\nwine '"${src}/perl.exe"' "${@}"' > "${dst}/perl"
+    echo -e '#!/usr/bin/env bash\nwine '"${src}/perl.exe"' "${@}"' > "${dst}/perl.exe"
+    chmod +x "${dst}/perl"
+    chmod +x "${dst}/perl.exe"
+
+    purge_packages
+
+    popd
+
+    rm -rf "${td}"
+
+    rm "${0}"
+}
+
+main "${@}"


### PR DESCRIPTION
Installs Strawberry perl and ensures it's the default on the path, and sets `WINEPATH`, `VSINSTALLDIR` and `VCINSTALLDIR` to ensure paths are properly set. Also fixes `cmd.exe` to ensure it's Windows cmd.

Closes #1.
Closes #2.