### PR TITLE
Add Apple Darwin targets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ The image names don't map identically to the target names, to avoid conflicting 
 |:-------------------------------------:|:-------------------------------------------:|
 | aarch64-pc-windows-msvc               | aarch64-pc-windows-msvc-cross               |
 | aarch64_be-unknown-linux-gnu          | aarch64_be-unknown-linux-gnu-cross          |
+| i686-apple-darwin                     | i686-apple-darwin-cross                     |
 | i686-pc-windows-msvc                  | i686-pc-windows-msvc-cross                  |
 | s390x-unknown-linux-gnu               | s390x-unknown-linux-gnu-cross               |
 | thumbv7a-pc-windows-msvc              | thumbv7a-pc-windows-msvc-cross              |
 | thumbv7neon-unknown-linux-musleabihf  | thumbv7neon-unknown-linux-musleabihf-cross  |
+| x86_64-apple-darwin                   | x86_64-apple-darwin-cross                   |
 | x86_64-pc-windows-msvc                | x86_64-pc-windows-msvc-cross                |
 
 For example, to build and run an image, you would configure the image with:
@@ -51,11 +53,28 @@ image = "ghcr.io/cross-rs/s390x-unknown-linux-gnu-cross:local"
 
 Additional config files for any [supported platforms](https://doc.rust-lang.org/rustc/platform-support.html) are appreciated. Please note that many of these images are tier 3 targets, and do not have pre-built versions of the standard library. You must provide the `build-std` [config](https://github.com/cross-rs/cross/wiki/Configuration) option when building crates requiring `std` support.
 
+# Apple Targets
+
+Due to licensing [reasons](https://www.apple.com/legal/sla/docs/xcode.pdf), we cannot provide images of `*-apple-darwin` targets, nor host the macOS SDK. osxcross has instructions for how to package the [sdk](https://github.com/tpoechtrager/osxcross#packaging-the-sdk), which you can then provide to the Docker image as either a local file or download link. Pre-packaged tarballs can also be found online, however, for legal reasons, we do not provide links here.
+
+You can provide either a download URL or a path to a local file when building:
+
+```bash
+$ cargo build-docker-image i686-apple-darwin \
+  --build-arg 'MACOS_SDK_URL=$URL'
+$ cargo build-docker-image i686-apple-darwin \
+  --build-arg 'MACOS_SDK_DIR=$DIR' \
+  --build-arg 'MACOS_SDK_FILE=$FILE'
+```
+
+If not provided, `MACOS_SDK_DIR` defaults to the build context of the Dockerfile. Note that this file must be a subdirectory of the build context.
+
 ## Known Issues
 
 - Older toolchains, such as GCC v4.9.4, do not work with the hardcoded ISL v0.20.
 - s390x toolchains cannot be built with glibc below v2.20, due to missing symbols in `nptl/sysdeps/s390/tls.h`.
 - aarch64_be toolchains cannot be built with older glibc versions, due relocations (tested to work in v2.31, failed in v2.20).
+- MSVC targets may fail with more complex build systems, such as OpenSSL.
 
 ## Code of Conduct
 

--- a/docker/Dockerfile.i686-apple-darwin-cross
+++ b/docker/Dockerfile.i686-apple-darwin-cross
@@ -1,0 +1,34 @@
+FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY common.sh lib.sh /
+RUN /common.sh
+
+COPY cmake.sh /
+RUN /cmake.sh
+
+COPY xargo.sh /
+RUN /xargo.sh
+
+# `MACOS_SDK_URL` or `MACOS_SDK_FILE` must be provided. `MACOS_SDK_FILE`
+# is the filename, while `MACOS_SDK_DIR` is the path relative to the current
+# build context. We will copy the filename from the root directory to
+# osxcross.
+ARG MACOS_SDK_DIR="."
+ARG MACOS_SDK_FILE="nonexistent"
+ARG MACOS_SDK_URL
+# wildcard workaround so we can copy the file only if it exists
+COPY $MACOS_SDK_DIR/$MACOS_SDK_FILE* /
+COPY cross-toolchains/docker/darwin.sh /
+RUN /darwin.sh
+
+ENV PATH=$PATH:/opt/osxcross/bin
+
+# by default, older versions of macOS (<10.9) link to libstdc++,
+# but rust expects it to link to libc++.
+ENV CARGO_TARGET_I686_APPLE_DARWIN_LINKER=i386-apple-darwin14-clang \
+    AR_i686_apple_darwin=i386-apple-darwin14-ar \
+    CFLAGS_i686_apple_darwin="-stdlib=libc++" \
+    CXXFLAGS_i686_apple_darwin="-stdlib=libc++" \
+    CC_i686_apple_darwin=i386-apple-darwin14-clang \
+    CXX_i686_apple_darwin=i386-apple-darwin14-clang++

--- a/docker/Dockerfile.x86_64-apple-darwin-cross
+++ b/docker/Dockerfile.x86_64-apple-darwin-cross
@@ -1,0 +1,34 @@
+FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY common.sh lib.sh /
+RUN /common.sh
+
+COPY cmake.sh /
+RUN /cmake.sh
+
+COPY xargo.sh /
+RUN /xargo.sh
+
+# `MACOS_SDK_URL` or `MACOS_SDK_FILE` must be provided. `MACOS_SDK_FILE`
+# is the filename, while `MACOS_SDK_DIR` is the path relative to the current
+# build context. We will copy the filename from the root directory to
+# osxcross.
+ARG MACOS_SDK_DIR="."
+ARG MACOS_SDK_FILE="nonexistent"
+ARG MACOS_SDK_URL
+# wildcard workaround so we can copy the file only if it exists
+COPY $MACOS_SDK_DIR/$MACOS_SDK_FILE* /
+COPY cross-toolchains/docker/darwin.sh /
+RUN /darwin.sh
+
+ENV PATH=$PATH:/opt/osxcross/bin
+
+# by default, older versions of macOS (<10.9) link to libstdc++,
+# but rust expects it to link to libc++.
+ENV CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=x86_64-apple-darwin14-clang \
+    AR_x86_64_apple_darwin=x86_64-apple-darwin14-ar \
+    CFLAGS_x86_64_apple_darwin="-stdlib=libc++" \
+    CXXFLAGS_x86_64_apple_darwin="-stdlib=libc++" \
+    CC_x86_64_apple_darwin=x86_64-apple-darwin14-clang \
+    CXX_x86_64_apple_darwin=x86_64-apple-darwin14-clang++

--- a/docker/darwin.sh
+++ b/docker/darwin.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -x
+set -eo pipefail
+
+# shellcheck disable=SC1091
+. lib.sh
+
+if [[ "${MACOS_SDK_FILE}" == "nonexistent" ]] && [[ -z "${MACOS_SDK_URL}" ]]; then
+    echo 'Must set the environment variable `MACOS_SDK_FILE` or `MACOS_SDK_URL`.' 1>&2
+    exit 1
+fi
+
+main() {
+    local commit=17bb5e2d0a46533c1dd525cf4e9a80d88bd9f00e
+
+    install_packages curl \
+        gcc \
+        g++ \
+        make \
+        patch \
+        xz-utils
+
+    apt-get update
+    apt-get install --assume-yes --no-install-recommends clang \
+        libmpc-dev \
+        libmpfr-dev \
+        libgmp-dev \
+        libssl-dev \
+        libxml2-dev \
+        zlib1g-dev
+
+    local td
+    td="$(mktemp -d)"
+
+    pushd "${td}"
+    git clone https://github.com/tpoechtrager/osxcross --depth 1
+    cd osxcross
+    git fetch --depth=1 origin "${commit}"
+    git checkout "${commit}"
+
+    if [[ -f /"${MACOS_SDK_FILE}" ]]; then
+        cp /"${MACOS_SDK_FILE}" tarballs/
+    else
+        pushd tarballs
+        curl --retry 3 -sSfL "${MACOS_SDK_URL}" -O
+        popd
+    fi
+
+    mkdir -p /opt/osxcross
+    TARGET_DIR=/opt/osxcross UNATTENDED=yes OSX_VERSION_MIN=10.7 ./build.sh
+
+    purge_packages
+
+    popd
+
+    rm -rf "${td}"
+    rm "${0}"
+}
+
+main "${@}"


### PR DESCRIPTION
Creates dockerfiles for the `*-apple-darwin` targets, and provides the build arguments `MACOS_SDK_URL` or `MACOS_SDK_FILE` and `MACOS_SDK_DIR` to find the pre-packaged tarball for the macOS SDK.

Instructions on how to use the variables is documented in the README.