### PR TITLE
Add support for `aarch64-apple-ios`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The image names don't map identically to the target names, to avoid conflicting 
 
 | Target Name                           | Image Name                                  |
 |:-------------------------------------:|:-------------------------------------------:|
+| aarch64-apple-ios                     | aarch64-apple-ios-cross                     |
 | aarch64-pc-windows-msvc               | aarch64-pc-windows-msvc-cross               |
 | aarch64_be-unknown-linux-gnu          | aarch64_be-unknown-linux-gnu-cross          |
 | i686-apple-darwin                     | i686-apple-darwin-cross                     |
@@ -57,6 +58,8 @@ Additional config files for any [supported platforms](https://doc.rust-lang.org/
 
 Due to licensing [reasons](https://www.apple.com/legal/sla/docs/xcode.pdf), we cannot provide images of `*-apple-darwin` targets, nor host the macOS SDK. osxcross has instructions for how to package the [sdk](https://github.com/tpoechtrager/osxcross#packaging-the-sdk), which you can then provide to the Docker image as either a local file or download link. Pre-packaged tarballs can also be found online, however, for legal reasons, we do not provide links here.
 
+### Darwin Targets
+
 You can provide either a download URL or a path to a local file when building:
 
 ```bash
@@ -69,12 +72,38 @@ $ cargo build-docker-image i686-apple-darwin-cross \
 
 If not provided, `MACOS_SDK_DIR` defaults to the build context of the Dockerfile. Note that this file must be a subdirectory of the build context.
 
+Supported targets by SDK version (at least 10.7+):
+- `i686-apple-darwin`: SDK <= 10.13
+- `x86_64-apple-darwin`: any SDK version
+- `aarc64-apple-darwin`: SDK >= 10.16
+
+### iOS Targets
+
+You can provide either a download URL or a path to a local file when building:
+
+```bash
+$ cargo build-docker-image aarch64-apple-ios-cross \
+  --build-arg 'IOS_SDK_URL=$URL'
+$ cargo build-docker-image aarch64-apple-ios-cross \
+  --build-arg 'IOS_SDK_DIR=$DIR' \
+  --build-arg 'IOS_SDK_FILE=$FILE'
+```
+
+If not provided, `IOS_SDK_DIR` defaults to the build context of the Dockerfile. Note that this file must be a subdirectory of the build context.
+
+Supported targets by SDK version (at least 9.3+):
+- `aarc64-apple-ios`: any SDK version
+- `armv7-apple-ios`: not supported
+- `armv7s-apple-ios`: not supported
+- `i686-apple-ios`: not supported
+- `x86_64-apple-ios`: not supported
+
 ## Known Issues
 
 - Older toolchains, such as GCC v4.9.4, do not work with the hardcoded ISL v0.20.
 - s390x toolchains cannot be built with glibc below v2.20, due to missing symbols in `nptl/sysdeps/s390/tls.h`.
 - aarch64_be toolchains cannot be built with older glibc versions, due relocations (tested to work in v2.31, failed in v2.20).
-- MSVC targets may fail with more complex build systems, such as OpenSSL.
+- MSVC and iOS targets may fail with more complex build systems, such as OpenSSL. macOS targets have no issues.
 
 ## Code of Conduct
 

--- a/docker/Dockerfile.aarch64-apple-ios-cross
+++ b/docker/Dockerfile.aarch64-apple-ios-cross
@@ -1,0 +1,35 @@
+FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY common.sh lib.sh /
+RUN /common.sh
+
+COPY cmake.sh /
+RUN /cmake.sh
+
+COPY xargo.sh /
+RUN /xargo.sh
+
+# `IOS_SDK_URL` or `IOS_SDK_FILE` must be provided. `IOS_SDK_FILE`
+# is the filename, while `IOS_SDK_DIR` is the path relative to the current
+# build context. We will copy the filename from the root directory to
+# osxcross.
+ARG IOS_SDK_DIR="."
+ARG IOS_SDK_FILE="nonexistent"
+ARG IOS_SDK_URL
+ARG TARGET_CPU=arm64
+ENV CROSS_TARGET=aarch64-apple-ios
+# wildcard workaround so we can copy the file only if it exists
+COPY $IOS_SDK_DIR/$IOS_SDK_FILE* /
+COPY cross-toolchains/docker/ios.sh /
+COPY cross-toolchains/docker/ios-wrapper.c /
+RUN /ios.sh $CROSS_TARGET $TARGET_CPU
+
+COPY cross-toolchains/docker/ios-entry.sh /
+ENTRYPOINT ["/ios-entry.sh"]
+
+ENV PATH=$PATH:/opt/cctools/bin  \
+    CARGO_TARGET_AARCH64_APPLE_IOS_LINKER=$CROSS_TARGET-clang \
+    AR_aarch64_apple_ios=$CROSS_TARGET-ar \
+    CC_aarch64_apple_ios=$CROSS_TARGET-clang \
+    CXX_aarch64_apple_ios=$CROSS_TARGET-clang++

--- a/docker/ios-entry.sh
+++ b/docker/ios-entry.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+# export the SDK home
+sdk_home="/opt/cctools/SDK"
+sdk_name=$(ls -t -1 "${sdk_home}" | head -1)
+export SDKROOT="${sdk_home}/${sdk_name}"
+
+# export the bindgen args
+envvar_suffix="${CROSS_TARGET//-/_}"
+declare -x BINDGEN_EXTRA_CLANG_ARGS_$envvar_suffix="--sysroot=${SDKROOT}/usr"
+
+exec "$@"

--- a/docker/ios-wrapper.c
+++ b/docker/ios-wrapper.c
@@ -1,0 +1,198 @@
+// Adapted from cctools-port
+//  https://github.com/tpoechtrager/cctools-port/tree/master/usage_examples/ios_toolchain
+// This code is public domain
+//  https://github.com/tpoechtrager/cctools-port/issues/21#issuecomment-223382676
+
+#ifndef OS_VER_MIN
+#define OS_VER_MIN "4.2"
+#endif
+
+#ifndef SDK_DIR
+#define SDK_DIR ""
+#endif
+
+#define _GNU_SOURCE
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <unistd.h>
+#include <limits.h>
+
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
+
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+#include <sys/sysctl.h>
+#endif
+
+#ifdef __OpenBSD__
+#include <sys/types.h>
+#include <sys/user.h>
+#include <sys/stat.h>
+#endif
+
+char *get_executable_path(char *epath, size_t buflen)
+{
+    char *p;
+#ifdef __APPLE__
+    unsigned int l = buflen;
+    if (_NSGetExecutablePath(epath, &l) != 0) return NULL;
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
+    int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
+    size_t l = buflen;
+    if (sysctl(mib, 4, epath, &l, NULL, 0) != 0) return NULL;
+#elif defined(__OpenBSD__)
+    int mib[4];
+    char **argv;
+    size_t len;
+    size_t l;
+    const char *comm;
+    int ok = 0;
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_PROC_ARGS;
+    mib[2] = getpid();
+    mib[3] = KERN_PROC_ARGV;
+    if (sysctl(mib, 4, NULL, &len, NULL, 0) < 0)
+        abort();
+    if (!(argv = malloc(len)))
+        abort();
+    if (sysctl(mib, 4, argv, &len, NULL, 0) < 0)
+        abort();
+    comm = argv[0];
+    if (*comm == '/' || *comm == '.')
+    {
+        char *rpath;
+        if ((rpath = realpath(comm, NULL)))
+        {
+            strlcpy(epath, rpath, buflen);
+            free(rpath);
+            ok = 1;
+        }
+    }
+    else
+    {
+        char *sp;
+        char *xpath = strdup(getenv("PATH"));
+        char *path = strtok_r(xpath, ":", &sp);
+        struct stat st;
+        if (!xpath)
+            abort();
+        while (path)
+        {
+            snprintf(epath, buflen, "%s/%s", path, comm);
+            if (!stat(epath, &st) && (st.st_mode & S_IXUSR))
+        {
+                ok = 1;
+                break;
+            }
+            path = strtok_r(NULL, ":", &sp);
+        }
+        free(xpath);
+    }
+    free(argv);
+    if (!ok) return NULL;
+    l = strlen(epath);
+#else
+    ssize_t l = readlink("/proc/self/exe", epath, buflen - 1);
+    if (l > 0) epath[l] = '\0';
+#endif
+    if (l <= 0) return NULL;
+    epath[buflen - 1] = '\0';
+    p = strrchr(epath, '/');
+    if (p) *p = '\0';
+    return epath;
+}
+
+char *get_filename(char *str)
+{
+    char *p = strrchr(str, '/');
+    return p ? &p[1] : str;
+}
+
+void target_info(char *argv[], char **triple, char **compiler)
+{
+    char *p = get_filename(argv[0]);
+    char *x = strrchr(p, '-');
+    if (!x) abort();
+    *compiler = &x[1];
+    *x = '\0';
+    *triple = p;
+}
+
+void env(char **p, const char *name, char *fallback)
+{
+    char *ev = getenv(name);
+    if (ev) { *p = ev; return; }
+    *p = fallback;
+}
+
+int main(int argc, char *argv[])
+{
+    char **args = alloca(sizeof(char*) * (argc+50));
+    int i, j;
+
+    char execpath[PATH_MAX+1];
+    char sdkpath[PATH_MAX+1];
+    char osvermin[64];
+
+    char *compiler;
+    char *target;
+
+    char *sdk;
+    char *cpu;
+    char *osmin;
+
+    target_info(argv, &target, &compiler);
+    if (!get_executable_path(execpath, sizeof(execpath))) abort();
+    snprintf(sdkpath, sizeof(sdkpath) - 1, "%s/../SDK/" SDK_DIR, execpath);
+
+    env(&sdk, "IOS_SDK_SYSROOT", sdkpath);
+    env(&cpu, "IOS_TARGET_CPU", TARGET_CPU);
+
+    env(&osmin, "IPHONEOS_DEPLOYMENT_TARGET", OS_VER_MIN);
+    unsetenv("IPHONEOS_DEPLOYMENT_TARGET");
+
+    snprintf(osvermin, sizeof(osvermin), "-miphoneos-version-min=%s", osmin);
+
+    for (i = 1; i < argc; ++i)
+    {
+        if (!strcmp(argv[i], "-arch"))
+        {
+            cpu = NULL;
+            break;
+        }
+    }
+
+    i = 0;
+
+    args[i++] = compiler;
+    args[i++] = "-target";
+    args[i++] = target;
+    args[i++] = "-isysroot";
+    args[i++] = sdk;
+
+    if (cpu)
+    {
+        args[i++] = "-arch";
+        args[i++] = cpu;
+    }
+
+    args[i++] = osvermin;
+    args[i++] = "-mlinker-version=609";
+    args[i++] = "-Wl,-adhoc_codesign";
+    args[i++] = "-Wno-unused-command-line-argument";
+
+    for (j = 1; j < argc; ++i, ++j)
+        args[i] = argv[j];
+
+    args[i] = NULL;
+
+    setenv("COMPILER_PATH", execpath, 1);
+    execvp(compiler, args);
+
+    fprintf(stderr, "cannot invoke compiler!\n");
+    return 1;
+}

--- a/docker/ios.sh
+++ b/docker/ios.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Adapted from cctools-port
+#   https://github.com/tpoechtrager/cctools-port/tree/master/usage_examples/ios_toolchain
+# This code is public domain
+#   https://github.com/tpoechtrager/cctools-port/issues/21#issuecomment-223382676
+
+set -x
+set -eo pipefail
+
+# shellcheck disable=SC1091
+. lib.sh
+
+if [[ "${IOS_SDK_FILE}" == "nonexistent" ]] && [[ -z "${IOS_SDK_URL}" ]]; then
+    echo 'Must set the environment variable `IOS_SDK_FILE` or `IOS_SDK_URL`.' 1>&2
+    exit 1
+fi
+
+get_sdk_version() {
+    local version
+    version=$(echo "${1}" | grep -P -o "[0-9][0-9].[0-9]+" | head -1)
+    if [ -z "${version}" ]; then
+      version=$(echo "${1}" | grep -P -o "[0-9].[0-9]+" | head -1)
+    fi
+    if [ -z "${version}" ]; then
+        echo "iPhoneOS Version must be in the SDK filename!" 1>&2
+        exit 1
+    fi
+
+    echo "${version}"
+}
+
+extract() {
+    local tarball="${1}"
+    local outdir="${2}"
+    mkdir -p "${outdir}"
+
+    case $1 in
+        *.tar.xz|*.txz)
+            tar -xJf "${tarball}" --directory "${2}"
+            ;;
+        *.tar.gz|*.tgz)
+            tar -xzf "${tarball}" --directory "${2}"
+            ;;
+        *.tar.bz2|*.tbz2)
+            tar -xjf "${tarball}" --directory "${2}"
+            ;;
+        *)
+            echo "unhandled archive type" 1>&2
+            exit 1
+            ;;
+    esac
+}
+
+main() {
+    local target="${1}"
+    local target_cpu="${2}"
+    local ldid_commit="4bf8f4d60384a0693dbbe2084ce62a35bfeb87ab"
+    local libtapi_commit="b7b5bdbfda9e8062d405b48da3b811afad98ae76"
+    local cctools_commit="04663295d0425abfac90a42440a7ec02d7155fea"
+    local install_dir="/opt/cctools"
+    local sdk_dir="${install_dir}"/SDK
+
+    install_packages curl \
+        gcc \
+        g++ \
+        make
+
+    apt-get update
+    apt-get install --assume-yes --no-install-recommends clang \
+        libbz2-dev \
+        libssl-dev \
+        libxml2-dev \
+        zlib1g-dev \
+        xz-utils \
+        llvm-dev\
+        uuid-dev\
+        libdispatch0
+
+    local td
+    td="$(mktemp -d)"
+    pushd "${td}"
+
+    # first, extract the SDK and get the version.
+    mkdir sdk
+    pushd sdk
+    if [[ -f /"${IOS_SDK_FILE}" ]]; then
+        cp /"${IOS_SDK_FILE}" .
+    else
+        curl --retry 3 -sSfL "${IOS_SDK_URL}" -O
+    fi
+    filename=$(ls -t -1 . | head -1)
+    sdk_version=$(get_sdk_version "${filename}")
+    extract "${filename}" SDK
+
+    # now, need to get our metadata, and move the SDK to the output dir
+    mkdir -p "${install_dir}"
+    mv SDK "${sdk_dir}"
+    local syslib
+    syslib=$(find "${sdk_dir}" -name libSystem.dylib -o -name libSystem.tbd | head -n1)
+    local wrapper_sdkdir
+    pushd "${sdk_dir}"
+    wrapper_sdkdir=$(echo iPhoneOS*sdk | head -n1)
+    popd
+    popd
+
+    mkdir -p ios-wrapper
+    pushd ios-wrapper
+    cp /ios-wrapper.c .
+    # want targets like armv7s, arm64
+    mkdir -p "${install_dir}/bin"
+    local clang="${install_dir}/bin/${target}-clang"
+    gcc -O2 -Wall -Wextra -pedantic ios-wrapper.c \
+        -DSDK_DIR="\"${wrapper_sdkdir}\"" \
+        -DTARGET_CPU="\"${target_cpu}"\" \
+        -DOS_VER_MIN="\"${sdk_version}"\" \
+        -o "${clang}"
+    popd
+
+    # build our apple dependencies
+    git clone https://github.com/tpoechtrager/ldid.git --depth 1
+    pushd ldid
+    git fetch --depth=1 origin "${ldid_commit}"
+    make INSTALLPREFIX="${install_dir}" -j install
+    popd
+
+    git clone https://github.com/tpoechtrager/apple-libtapi.git --depth 1
+    pushd apple-libtapi
+    git fetch --depth=1 origin "${libtapi_commit}"
+    INSTALLPREFIX="${install_dir}" ./build.sh
+    ./install.sh
+    popd
+
+    # valid targets include `aarch64-apple-ios`
+    git clone https://github.com/tpoechtrager/cctools-port.git --depth 1
+    pushd cctools-port/cctools
+    git fetch --depth=1 origin "${cctools_commit}"
+    ./configure \
+        --prefix="${install_dir}" \
+        --with-libtapi="${install_dir}" \
+        --target="${target}"
+    make -j
+    make install
+    popd
+
+    # make a symlink since clang is both a c and c++ compiler
+    ln -sf "${clang}" "${clang}"++
+
+    # need a fake wrapper for xcrun, which is used by `cc`.
+    echo '#!/usr/bin/env sh
+echo "${SDKROOT}"
+' > "${install_dir}/bin/xcrun"
+chmod +x "${install_dir}/bin/xcrun"
+
+    purge_packages
+
+    popd
+
+    rm -rf "${td}"
+    rm ios-wrapper.c
+    rm "${0}"
+}
+
+main "${@}"


### PR DESCRIPTION
Add rudimentary support for ARM64 iOS targets. This checks that C++ libraries, including those like bzip2, compile, but has not been tested to see if the binaries properly run on the target system.

Other iOS targets were tested, but did not work, including:
- `armv7-apple-ios`
- `armv7s-apple-ios`
- `i686-apple-ios`
- `x86_64-apple-ios`

Closes #6.