### PR TITLE
add x86_64-apple-ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ $ cargo build-docker-image aarch64-apple-ios-cross \
 If not provided, `IOS_SDK_DIR` defaults to the build context of the Dockerfile. Note that this file must be a subdirectory of the build context.
 
 Supported targets by SDK version (at least 9.3+):
-- `aarch64-apple-ios`: any SDK version
+- `aarch64-apple-ios`: any iPhoneOS SDK version
 - `armv7-apple-ios`: not supported
 - `armv7s-apple-ios`: not supported
 - `i686-apple-ios`: not supported
-- `x86_64-apple-ios`: not supported
+- `x86_64-apple-ios`: any iPhoneSimulator SDK version
 
 ## Known Issues
 

--- a/docker/Dockerfile.x86_64-apple-ios-cross
+++ b/docker/Dockerfile.x86_64-apple-ios-cross
@@ -33,7 +33,7 @@ ENTRYPOINT ["/ios-entry.sh"]
 
 ENV CROSS_SYSROOT=/opt/cctools/SDK/latest/usr
 ENV PATH=$PATH:/opt/cctools/bin  \
-    CARGO_TARGET_AARCH64_APPLE_IOS_LINKER=$CROSS_TARGET-clang \
+    CARGO_TARGET_X86_64_APPLE_IOS_LINKER=$CROSS_TARGET-clang \
     AR_x86_64_apple_ios=$CROSS_TARGET-ar \
     CC_x86_64_apple_ios=$CROSS_TARGET-clang \
     CXX_x86_64_apple_ios=$CROSS_TARGET-clang++

--- a/docker/Dockerfile.x86_64-apple-ios-cross
+++ b/docker/Dockerfile.x86_64-apple-ios-cross
@@ -1,0 +1,39 @@
+FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY common.sh lib.sh /
+RUN /common.sh
+
+COPY cmake.sh /
+RUN /cmake.sh
+
+COPY xargo.sh /
+RUN /xargo.sh
+
+# `IOS_SDK_URL` or `IOS_SDK_FILE` must be provided. `IOS_SDK_FILE`
+# is the filename, while `IOS_SDK_DIR` is the path relative to the current
+# build context. We will copy the filename from the root directory to
+# osxcross.
+ARG IOS_SDK_DIR="."
+ARG IOS_SDK_FILE="nonexistent"
+ARG IOS_SDK_URL
+ARG TARGET_CPU=x86_64
+ENV CROSS_TARGET=x86_64-apple-ios
+# wildcard workaround so we can copy the file only if it exists
+COPY $IOS_SDK_DIR/$IOS_SDK_FILE /
+COPY cross-toolchains/docker/ios.sh /
+COPY cross-toolchains/docker/ios-wrapper.c /
+RUN /ios.sh $CROSS_TARGET $TARGET_CPU
+
+COPY cross-toolchains/docker/ios-symlink.sh /
+RUN /ios-symlink.sh
+
+COPY cross-toolchains/docker/ios-entry.sh /
+ENTRYPOINT ["/ios-entry.sh"]
+
+ENV CROSS_SYSROOT=/opt/cctools/SDK/latest/usr
+ENV PATH=$PATH:/opt/cctools/bin  \
+    CARGO_TARGET_AARCH64_APPLE_IOS_LINKER=$CROSS_TARGET-clang \
+    AR_x86_64_apple_ios=$CROSS_TARGET-ar \
+    CC_x86_64_apple_ios=$CROSS_TARGET-clang \
+    CXX_x86_64_apple_ios=$CROSS_TARGET-clang++


### PR DESCRIPTION
```sh
root@606c2aa09410:~# x86_64-apple-ios-clang c.c          
root@606c2aa09410:~# file ./a.out 
./a.out: Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>
```

Need to change the hardcoded `iPhoneOS*sdk` to `iPhoneSimulator*sdk`, I just made a symlink in `/opt/cctools/SDK` for testing but need to refactor `ios.sh` for a proper fix

PS: I have no idea what I'm doing