### PR TITLE
enforce newlines on windows checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+
+Dockerfile.* linguist-language=Dockerfile eol=lf

--- a/docker/.gitattributes
+++ b/docker/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
This is the same change as in https://github.com/cross-rs/cross/pull/1154. 

Part of the motivation of this changes is that it forces windows checkouts to use LF on .sh files. I was previously getting errors related to the .sh files being checked out with `CRLF` due to `core.autocrlf=true` on my dev machine.

fixes #35 