### PR TITLE
Fix typos: aarc64 -> aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ If not provided, `MACOS_SDK_DIR` defaults to the build context of the Dockerfile
 
 ```bash
 $ mv osxcross/MacOSX11.3.sdk.tar.xz cross-toolchains/docker/MacOSX11.3.sdk.tar.xz
-$ cargo build-docker-image aarc64-apple-darwin \
+$ cargo build-docker-image aarch64-apple-darwin \
   --build-arg 'MACOS_SDK_FILE=MacOSX11.3.sdk.tar.xz'
 # or
 $ mv osxcross/MacOSX11.3.sdk.tar.xz cross-toolchains/docker/some-dir/MacOSX11.3.sdk.tar.xz
-$ cargo build-docker-image aarc64-apple-darwin \
+$ cargo build-docker-image aarch64-apple-darwin \
   --build-arg 'MACOS_SDK_DIR=some-dir' \
   --build-arg 'MACOS_SDK_FILE=MacOSX11.3.sdk.tar.xz'
 ```
@@ -97,7 +97,7 @@ $ cargo build-docker-image aarc64-apple-darwin \
 Supported targets by SDK version (at least 10.7+):
 - `i686-apple-darwin`: SDK <= 10.13
 - `x86_64-apple-darwin`: SDK <= 13.0 or SDK <= 12.4
-- `aarc64-apple-darwin`: SDK >= 10.16 and (SDK <= 13.0 or SDK <= 12.4)
+- `aarch64-apple-darwin`: SDK >= 10.16 and (SDK <= 13.0 or SDK <= 12.4)
 
 ### iOS Targets
 


### PR DESCRIPTION
I believe this is a spelling mistake?