### PR TITLE
Add support for building images for `x86_64-apple-darwin` and `aarch64-apple-darwin` for SDK version 15

### DIFF
--- a/docker/Dockerfile.aarch64-apple-darwin-cross
+++ b/docker/Dockerfile.aarch64-apple-darwin-cross
@@ -28,6 +28,8 @@ RUN /darwin-symlink.sh
 ENV CROSS_SYSROOT=/opt/osxcross/SDK/latest/
 ENV PATH=$PATH:/opt/osxcross/bin \
     CROSS_TARGET=aarch64-apple-darwin
+# Required for bindgen to find the system headers.
+ENV BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_darwin="--sysroot=$CROSS_SYSROOT -idirafter/usr/include"
 
 COPY cross-toolchains/docker/darwin-entry.sh /
 ENTRYPOINT ["/darwin-entry.sh"]

--- a/docker/Dockerfile.aarch64-apple-darwin-cross
+++ b/docker/Dockerfile.aarch64-apple-darwin-cross
@@ -25,7 +25,7 @@ RUN /darwin.sh
 COPY cross-toolchains/docker/darwin-symlink.sh /
 RUN /darwin-symlink.sh
 
-ENV CROSS_SYSROOT=/opt/osxcross/SDK/MacOSX15.sdk/
+ENV CROSS_SYSROOT=/opt/osxcross/SDK/latest/usr
 ENV PATH=$PATH:/opt/osxcross/bin \
     CROSS_TARGET=aarch64-apple-darwin
 

--- a/docker/Dockerfile.aarch64-apple-darwin-cross
+++ b/docker/Dockerfile.aarch64-apple-darwin-cross
@@ -25,7 +25,7 @@ RUN /darwin.sh
 COPY cross-toolchains/docker/darwin-symlink.sh /
 RUN /darwin-symlink.sh
 
-ENV CROSS_SYSROOT=/opt/osxcross/SDK/latest/usr
+ENV CROSS_SYSROOT=/opt/osxcross/SDK/latest/
 ENV PATH=$PATH:/opt/osxcross/bin \
     CROSS_TARGET=aarch64-apple-darwin
 

--- a/docker/Dockerfile.aarch64-apple-darwin-cross
+++ b/docker/Dockerfile.aarch64-apple-darwin-cross
@@ -25,7 +25,7 @@ RUN /darwin.sh
 COPY cross-toolchains/docker/darwin-symlink.sh /
 RUN /darwin-symlink.sh
 
-ENV CROSS_SYSROOT=/opt/osxcross/SDK/latest/usr
+ENV CROSS_SYSROOT=/opt/osxcross/SDK/MacOSX15.sdk/
 ENV PATH=$PATH:/opt/osxcross/bin \
     CROSS_TARGET=aarch64-apple-darwin
 

--- a/docker/Dockerfile.x86_64-apple-darwin-cross
+++ b/docker/Dockerfile.x86_64-apple-darwin-cross
@@ -28,6 +28,8 @@ RUN /darwin-symlink.sh
 ENV CROSS_SYSROOT=/opt/osxcross/SDK/latest/
 ENV PATH=$PATH:/opt/osxcross/bin \
     CROSS_TARGET=x86_64-apple-darwin
+# Required for bindgen to find the system headers.
+ENV BINDGEN_EXTRA_CLANG_ARGS_x86_64_apple_darwin="--sysroot=$CROSS_SYSROOT -idirafter/usr/include"
 
 COPY cross-toolchains/docker/darwin-entry.sh /
 ENTRYPOINT ["/darwin-entry.sh"]

--- a/docker/Dockerfile.x86_64-apple-darwin-cross
+++ b/docker/Dockerfile.x86_64-apple-darwin-cross
@@ -25,7 +25,7 @@ RUN /darwin.sh
 COPY cross-toolchains/docker/darwin-symlink.sh /
 RUN /darwin-symlink.sh
 
-ENV CROSS_SYSROOT=/opt/osxcross/SDK/latest/usr
+ENV CROSS_SYSROOT=/opt/osxcross/SDK/latest/
 ENV PATH=$PATH:/opt/osxcross/bin \
     CROSS_TARGET=x86_64-apple-darwin
 

--- a/docker/darwin-entry.sh
+++ b/docker/darwin-entry.sh
@@ -23,5 +23,6 @@ declare -x CARGO_TARGET_${upper_suffix}_LINKER="${tools_prefix}"-clang
 # let the clang wrapper to use its own linker in the osxcross bin path.
 declare -x CFLAGS_${envvar_suffix}="-stdlib=libc++ -fuse-ld=${tools_prefix}-ld"
 declare -x CXXFLAGS_${envvar_suffix}="-stdlib=libc++ -fuse-ld=${tools_prefix}-ld"
+declare -rx BINDGEN_EXTRA_CLANG_ARGS_${envvar_suffix}="--sysroot=${CROSS_SYSROOT} -idirafter/usr/include"
 
 exec "$@"

--- a/docker/darwin-entry.sh
+++ b/docker/darwin-entry.sh
@@ -23,7 +23,5 @@ declare -x CARGO_TARGET_${upper_suffix}_LINKER="${tools_prefix}"-clang
 # let the clang wrapper to use its own linker in the osxcross bin path.
 declare -x CFLAGS_${envvar_suffix}="-stdlib=libc++ -fuse-ld=${tools_prefix}-ld"
 declare -x CXXFLAGS_${envvar_suffix}="-stdlib=libc++ -fuse-ld=${tools_prefix}-ld"
-# Required for bindgen to find the system headers.
-declare -rx BINDGEN_EXTRA_CLANG_ARGS_${envvar_suffix}="--sysroot=${CROSS_SYSROOT} -idirafter/usr/include"
 
 exec "$@"

--- a/docker/darwin-entry.sh
+++ b/docker/darwin-entry.sh
@@ -23,6 +23,7 @@ declare -x CARGO_TARGET_${upper_suffix}_LINKER="${tools_prefix}"-clang
 # let the clang wrapper to use its own linker in the osxcross bin path.
 declare -x CFLAGS_${envvar_suffix}="-stdlib=libc++ -fuse-ld=${tools_prefix}-ld"
 declare -x CXXFLAGS_${envvar_suffix}="-stdlib=libc++ -fuse-ld=${tools_prefix}-ld"
+# Required for bindgen to find the system headers.
 declare -rx BINDGEN_EXTRA_CLANG_ARGS_${envvar_suffix}="--sysroot=${CROSS_SYSROOT} -idirafter/usr/include"
 
 exec "$@"

--- a/docker/darwin.sh
+++ b/docker/darwin.sh
@@ -11,8 +11,30 @@ if [[ "${MACOS_SDK_FILE}" == "nonexistent" ]] && [[ -z "${MACOS_SDK_URL}" ]]; th
     exit 1
 fi
 
+die() {
+    printf 1>&2 "%s\n" "${@}"
+    exit 1
+}
+
+install_llvm() {
+    [ "${#}" -eq 1 ] || die "No version provided"
+
+    declare -r generated_tmp_dir=$(mktemp -d -t)
+    declare -r llvm_version="${1}"
+
+    pushd "${generated_tmp_dir}"
+
+    curl -LO https://apt.llvm.org/llvm.sh
+    chmod +x llvm.sh
+    ./llvm.sh "${llvm_version}"
+
+    popd
+
+    rm -rf "${generated_tmp_dir}"
+}
+
 main() {
-    local commit=ff8d100f3f026b4ffbe4ce96d8aac4ce06f1278b
+    local commit=83daa9c65fbdcd7a9b867cd198f40b9564d06653
 
     install_packages curl \
         gcc \
@@ -20,10 +42,16 @@ main() {
         make \
         patch \
         xz-utils \
-        python3
+        python3 \
+        lsb-release \
+        software-properties-common \
+        gnupg \
+        bzip2
+    
+    install_llvm 15
 
     apt-get update
-    apt-get install --assume-yes --no-install-recommends clang \
+    apt-get install --assume-yes --no-install-recommends \
         libmpc-dev \
         libmpfr-dev \
         libgmp-dev \

--- a/docker/darwin.sh
+++ b/docker/darwin.sh
@@ -31,6 +31,9 @@ install_llvm() {
     popd
 
     rm -rf "${generated_tmp_dir}"
+
+    ln -s /usr/bin/clang-${llvm_version} /usr/bin/clang 
+    ln -s /usr/bin/clang++-${llvm_version} /usr/bin/clang++
 }
 
 main() {

--- a/docker/darwin.sh
+++ b/docker/darwin.sh
@@ -41,6 +41,10 @@ main() {
     # adds support for compiling up to SDK version 15.4
     local commit=83daa9c65fbdcd7a9b867cd198f40b9564d06653
 
+    # lsb-release: Needed for fetching version of OS in llvm.sh
+    # software-properties-common: Required by llvm.sh
+    # gnupg: Required by llvm.sh
+    # bzip2: Need bzip2 for unzipping .bz2 files.
     install_packages curl \
         gcc \
         g++ \
@@ -51,7 +55,6 @@ main() {
         lsb-release \
         software-properties-common \
         gnupg \
-        # Need bzip2 for unzipping .bz2 files.
         bzip2
 
     # The Clang version shipped with the apt package registry for

--- a/docker/darwin.sh
+++ b/docker/darwin.sh
@@ -32,11 +32,13 @@ install_llvm() {
 
     rm -rf "${generated_tmp_dir}"
 
-    ln -s /usr/bin/clang-${llvm_version} /usr/bin/clang 
+    ln -s /usr/bin/clang-${llvm_version} /usr/bin/clang
     ln -s /usr/bin/clang++-${llvm_version} /usr/bin/clang++
 }
 
 main() {
+    # https://github.com/tpoechtrager/osxcross/commit/83daa9c65fbdcd7a9b867cd198f40b9564d06653
+    # adds support for compiling up to SDK version 15.4
     local commit=83daa9c65fbdcd7a9b867cd198f40b9564d06653
 
     install_packages curl \
@@ -49,8 +51,12 @@ main() {
         lsb-release \
         software-properties-common \
         gnupg \
+        # Need bzip2 for unzipping .bz2 files.
         bzip2
-    
+
+    # The Clang version shipped with the apt package registry for
+    # Ubuntu 20.04 is too old to compile the test files that includes
+    # the macOS SDK. Need to at least bump it up to major version 16.
     install_llvm 16
 
     apt-get update

--- a/docker/darwin.sh
+++ b/docker/darwin.sh
@@ -51,7 +51,7 @@ main() {
         gnupg \
         bzip2
     
-    install_llvm 15
+    install_llvm 16
 
     apt-get update
     apt-get install --assume-yes --no-install-recommends \


### PR DESCRIPTION
Hi,

I attempted some time last week with building a docker image for `aarch64-apple-darwin` that used the macOSX SDK version 15.4 but immediately encountered some issues with this:

* The version of `clang` shipped with the `apt` registry for Ubuntu 20.04 is quite old (major version 10). In order to compile the test executables that are being built with the `build.sh` script from [osxcross](https://github.com/tpoechtrager/osxcross/blob/83daa9c65fbdcd7a9b867cd198f40b9564d06653/build.sh), I had to at least use version 16. Therefore, this PR suggests fetching LLVM version 16 to use instead of the default provided version in `apt` for Ubuntu 20.04.
* Once I was able to create the Docker image, I had some trouble with getting `bindgen` to figure out where the new sysroot was pointing to. From what I understood, this is what the `BINDGEN_EXTRA_CLANG_ARGS_${envvar_suffix}` environment variable is used to. For some reason it was not set for the Darwin images, so I exported it in `darwin_entry.sh`.

I hope that this PR would be interesting and does not cause too much headache. Please let me know if there is anything I should correct, please let me know.

Thanks!