### PR TITLE
aarch64-pc-windows-msvc: Set BINDGEN_EXTRA_CLANG_ARGS

### DIFF
--- a/docker/Dockerfile.aarch64-pc-windows-msvc-cross
+++ b/docker/Dockerfile.aarch64-pc-windows-msvc-cross
@@ -36,4 +36,5 @@ ENV CARGO_TARGET_AARCH64_PC_WINDOWS_MSVC_LINKER=link.exe \
     WINEPATH="$WINEPATH;C:/windows/syswow64;C:/windows/system32;/opt/msvc/bin/$ARCH" \
     VSINSTALLDIR="/opt/msvc" \
     VCINSTALLDIR="/opt/msvc/vc" \
-    VSCMD_ARG_TGT_ARCH=$ARCH
+    VSCMD_ARG_TGT_ARCH=$ARCH \
+    BINDGEN_EXTRA_CLANG_ARGS="-I$CROSS_SYSROOT/include/"


### PR DESCRIPTION
For https://github.com/cross-rs/cross/pull/1672#issuecomment-2842083906 we need to append some includes to `clang` when running bindgen.  This is a quick hack to get it working for us, not sure what else we should pass.
