### PR TITLE
no more xargo

### DIFF
--- a/docker/Dockerfile.aarch64-apple-darwin-cross
+++ b/docker/Dockerfile.aarch64-apple-darwin-cross
@@ -7,9 +7,6 @@ RUN /common.sh
 COPY cmake.sh /
 RUN /cmake.sh
 
-COPY xargo.sh /
-RUN /xargo.sh
-
 # `MACOS_SDK_URL` or `MACOS_SDK_FILE` must be provided. `MACOS_SDK_FILE`
 # is the filename, while `MACOS_SDK_DIR` is the path relative to the current
 # build context. We will copy the filename from the root directory to

--- a/docker/Dockerfile.aarch64-apple-ios-cross
+++ b/docker/Dockerfile.aarch64-apple-ios-cross
@@ -7,9 +7,6 @@ RUN /common.sh
 COPY cmake.sh /
 RUN /cmake.sh
 
-COPY xargo.sh /
-RUN /xargo.sh
-
 # `IOS_SDK_URL` or `IOS_SDK_FILE` must be provided. `IOS_SDK_FILE`
 # is the filename, while `IOS_SDK_DIR` is the path relative to the current
 # build context. We will copy the filename from the root directory to

--- a/docker/Dockerfile.aarch64-pc-windows-msvc-cross
+++ b/docker/Dockerfile.aarch64-pc-windows-msvc-cross
@@ -7,9 +7,6 @@ RUN /common.sh
 COPY cmake.sh /
 RUN /cmake.sh
 
-COPY xargo.sh /
-RUN /xargo.sh
-
 # run these in separate steps, so we can cache MSVC between all images.
 COPY cross-toolchains/docker/msvc-wine.sh /
 RUN /msvc-wine.sh

--- a/docker/Dockerfile.aarch64_be-unknown-linux-gnu-cross
+++ b/docker/Dockerfile.aarch64_be-unknown-linux-gnu-cross
@@ -7,9 +7,6 @@ RUN /common.sh
 COPY cmake.sh /
 RUN /cmake.sh
 
-COPY xargo.sh /
-RUN /xargo.sh
-
 ARG VERBOSE
 COPY crosstool-ng.sh /
 COPY cross-toolchains/docker/crosstool-config/aarch64_be-unknown-linux-gnu-cross.config /

--- a/docker/Dockerfile.i686-apple-darwin-cross
+++ b/docker/Dockerfile.i686-apple-darwin-cross
@@ -7,9 +7,6 @@ RUN /common.sh
 COPY cmake.sh /
 RUN /cmake.sh
 
-COPY xargo.sh /
-RUN /xargo.sh
-
 # `MACOS_SDK_URL` or `MACOS_SDK_FILE` must be provided. `MACOS_SDK_FILE`
 # is the filename, while `MACOS_SDK_DIR` is the path relative to the current
 # build context. We will copy the filename from the root directory to

--- a/docker/Dockerfile.i686-pc-windows-msvc-cross
+++ b/docker/Dockerfile.i686-pc-windows-msvc-cross
@@ -7,9 +7,6 @@ RUN /common.sh
 COPY cmake.sh /
 RUN /cmake.sh
 
-COPY xargo.sh /
-RUN /xargo.sh
-
 # run these in separate steps, so we can cache MSVC between all images.
 COPY cross-toolchains/docker/msvc-wine.sh /
 RUN /msvc-wine.sh

--- a/docker/Dockerfile.s390x-unknown-linux-gnu-cross
+++ b/docker/Dockerfile.s390x-unknown-linux-gnu-cross
@@ -7,9 +7,6 @@ RUN /common.sh
 COPY cmake.sh /
 RUN /cmake.sh
 
-COPY xargo.sh /
-RUN /xargo.sh
-
 ARG VERBOSE
 COPY crosstool-ng.sh /
 COPY cross-toolchains/docker/crosstool-config/s390x-unknown-linux-gnu-cross.config /

--- a/docker/Dockerfile.thumbv7a-pc-windows-msvc-cross
+++ b/docker/Dockerfile.thumbv7a-pc-windows-msvc-cross
@@ -7,9 +7,6 @@ RUN /common.sh
 COPY cmake.sh /
 RUN /cmake.sh
 
-COPY xargo.sh /
-RUN /xargo.sh
-
 # run these in separate steps, so we can cache MSVC between all images.
 COPY cross-toolchains/docker/msvc-wine.sh /
 RUN /msvc-wine.sh

--- a/docker/Dockerfile.thumbv7neon-unknown-linux-musleabihf-cross
+++ b/docker/Dockerfile.thumbv7neon-unknown-linux-musleabihf-cross
@@ -7,9 +7,6 @@ RUN /common.sh
 COPY cmake.sh /
 RUN /cmake.sh
 
-COPY xargo.sh /
-RUN /xargo.sh
-
 COPY qemu.sh /
 RUN /qemu.sh arm
 

--- a/docker/Dockerfile.x86_64-apple-darwin-cross
+++ b/docker/Dockerfile.x86_64-apple-darwin-cross
@@ -7,9 +7,6 @@ RUN /common.sh
 COPY cmake.sh /
 RUN /cmake.sh
 
-COPY xargo.sh /
-RUN /xargo.sh
-
 # `MACOS_SDK_URL` or `MACOS_SDK_FILE` must be provided. `MACOS_SDK_FILE`
 # is the filename, while `MACOS_SDK_DIR` is the path relative to the current
 # build context. We will copy the filename from the root directory to

--- a/docker/Dockerfile.x86_64-pc-windows-msvc-cross
+++ b/docker/Dockerfile.x86_64-pc-windows-msvc-cross
@@ -7,9 +7,6 @@ RUN /common.sh
 COPY cmake.sh /
 RUN /cmake.sh
 
-COPY xargo.sh /
-RUN /xargo.sh
-
 # run these in separate steps, so we can cache MSVC between all images.
 COPY cross-toolchains/docker/msvc-wine.sh /
 RUN /msvc-wine.sh

--- a/docker/Dockerfile.x86_64-unknown-linux-gnu-sde-cross
+++ b/docker/Dockerfile.x86_64-unknown-linux-gnu-sde-cross
@@ -7,9 +7,6 @@ RUN /common.sh
 COPY cmake.sh /
 RUN /cmake.sh
 
-COPY xargo.sh /
-RUN /xargo.sh
-
 COPY cross-toolchains/docker/intel-sde.sh /
 RUN /intel-sde.sh
 


### PR DESCRIPTION
https://github.com/cross-rs/cross/pull/1709 removed xargo support, which involved removing xargo from all of the dockerfiles. The same was not done for the dockerfiles in this repo though, meaning that building these images has been broken since that PR.

This PR fixes that by removing xargo from the dockerfiles, as was done for the dockerfiles in the main repo. I tested this by attempting to build `x86_64-pc-windows-msvc-cross`, which failed on `xargo.sh` being missing before this PR, and worked after this PR.